### PR TITLE
Eslint rule for import order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,24 @@ module.exports = {
         reservedFirst: true,
       },
     ],
-    "simple-import-sort/imports": "error",
+    "import/order": [
+      "warn",
+      {
+        pathGroups: [
+          {
+            pattern: "@/common/**",
+            group: "external",
+            position: "after",
+          },
+          {
+            pattern: "@/modules/**",
+            group: "external",
+            position: "after",
+          },
+        ],
+        "newlines-between": "always",
+      },
+    ],
     "simple-import-sort/exports": "error",
     "import/first": "error",
     "import/newline-after-import": "error",


### PR DESCRIPTION
### Description:
- ordered import where: lib import(1) stays on top, then common(2), then modules(3) an rest of the others stay below
- each imports are separated with a new line in between

Preview:

https://user-images.githubusercontent.com/53527664/173537198-0f6b029d-7064-42ae-86a1-6936667f3192.mp4