### PR TITLE
fix: remove default font in global styles

### DIFF
--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -21,7 +21,3 @@ body,
 #__next {
   height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
 }
-
-body {
-  font-family: "GT-America";
-}


### PR DESCRIPTION
The default font in `body` makes the addition of custom fonts to be tricky.

This is because developers who just used this template will only add the `@font-face` in the global styles and `tailwind.config.js` and then proceed to add some random text with the new font-face to see if the new custom font is properly applied, unknowingly to them that the font will still be replaced by `font-family` in `body`.

Although it is known through `CSS Specificity` that class names take precedence over HTML tags, from my experience, the font often times gets replaced instead 😂 