### PR TITLE
Add organize import to code action on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,10 +22,11 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "editor.rulers": [80],
-  "editor.codeActionsOnSave": {
-    "source.addMissingImports": true,
-    "source.fixAll.eslint": true
-  },
+  "editor.codeActionsOnSave": [
+    "source.addMissingImports",
+    "source.fixAll",
+    "source.organizeImports"
+  ],
   // Show in vscode "Problems" tab when there are errors
   "typescript.tsserver.experimental.enableProjectDiagnostics": true,
   // Use absolute import for typescript files


### PR DESCRIPTION
## Description
Add organize import to code action on save.

### Screenshots / Videos
Notice, I have to press Cmd + S two times previously:

https://github.com/Aztriltus/nextjs-ts-tailwind-template/assets/53527664/361f4424-1030-4165-a275-f8f2394340a0

### How to test?
N/A
